### PR TITLE
Check project root before home directory for connections.yaml and .env

### DIFF
--- a/SQLconnect/config.py
+++ b/SQLconnect/config.py
@@ -8,13 +8,28 @@ from dotenv import load_dotenv
 def get_connection_config(connection_name: str, config_path: str = None) -> dict:
     """Using pathlib to read the YAML file."""
 
-    if config_path is not None:
-        config_text = Path(config_path).read_text(encoding="utf-8")
-    else:
-        config_text = Path("connections.yaml").read_text(encoding="utf-8")
+    # List of potential paths for the configuration file
+    config_paths = (
+        [Path(config_path)]
+        if config_path
+        else [
+            Path("connections.yaml"),
+            Path("connections.yml"),
+            Path.home() / "connections.yaml",
+            Path.home() / "connections.yml",
+        ]
+    )
 
-    config = yaml.safe_load(config_text)
-    return config["connections"][connection_name]
+    for path in config_paths:
+        if path.exists():
+            config_text = path.read_text(encoding="utf-8")
+            config = yaml.safe_load(config_text)
+            return config["connections"][connection_name]
+
+    raise FileNotFoundError(
+        f"Config file not found in {Path('connections.yaml').absolute()} "
+        f"or {Path.home() / 'connections.yaml'}"
+    )
 
 
 def get_db_url(connection_config: dict) -> str:
@@ -29,9 +44,24 @@ def get_db_url(connection_config: dict) -> str:
     # Check for username and password
     auth_details = ""
     if "username" in connection_config and "password" in connection_config:
-        load_dotenv()
-        username = os.getenv(connection_config["username"].strip("${}"))
-        password = os.getenv(connection_config["password"].strip("${}"))
+        if Path(".env").exists():
+            load_dotenv(Path(".env"))
+        else:
+            home_env_path = Path.home() / ".env"
+            if home_env_path.exists():
+                load_dotenv(home_env_path)
+
+        env_username_key = connection_config["username"].strip("${}")
+        env_password_key = connection_config["password"].strip("${}")
+        username = os.getenv(env_username_key)
+        password = os.getenv(env_password_key)
+
+        if username is None or password is None:
+            raise EnvironmentError(
+                f"Environment variables '{env_username_key}' and/or '{env_password_key}' not "
+                f"found in {Path(".env").absolute()} or {Path.home() / ".env"}"
+            )
+
         auth_details = f"{username}:{password}@"
 
     # Construct the connection string

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 setuptools.setup(
     name="SQLconnect",
-    version="0.1.0",
+    version="0.1.1",
     author="Justin Frizzell",
     description=""" Package to simplify connections to SQL databases. """,
     long_description=Path("README.md").read_text(encoding="utf=8"),


### PR DESCRIPTION
When setting up a database connection, SQLconnect will now check the root of the project for a connections.yaml and .env file. If one or both cannot be found, it will check the users home directory. Saving the configuration files in the home directory is useful if different projects need to share the same configuration, or if you want to reduce the chance of accidently committing .env to version control.

Here are example absolute paths for the home directory it will search on different operating systems:

1. **macOS/Linux**: 
   - The home directory path typically looks like `/Users/username` on macOS and `/home/username` on most Linux distributions.
   - Example path: `/Users/justin/connections.yaml` (macOS) or `/home/justin/connections.yaml` (Linux).

2. **Windows**:
   - On Windows, the home directory path often looks like `C:\Users\username`.
   - Example path: `C:\Users\justin\connections.yaml`.