### PR TITLE
Updated yaml structure

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,15 +3,6 @@ version: '3.8'
 services:
   app:
     build: .
-    depends_on:
-      postgres_db:
-        condition: service_started
-      mssql_db:
-        condition: service_started        
-      oracle_db:
-        condition: service_started        
-      mysql_db:
-        condition: service_started        
     environment:
       - RUNNING_IN_DOCKER=true        
     networks:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,7 +11,7 @@ services:
   postgres_db:
     image: postgres
     environment:
-      POSTGRES_PASSWORD: "mysecretpassword"
+      POSTGRES_PASSWORD: "test_p@ssword_f0r_CI!"
     ports:
       - "5432:5432"
     networks:
@@ -20,7 +20,7 @@ services:
   mssql_db:
     image: mcr.microsoft.com/mssql/server:2019-latest
     environment:
-      SA_PASSWORD: "MySecretPassw0rd!"
+      SA_PASSWORD: "test_p@ssword_f0r_CI!"
       ACCEPT_EULA: "Y"
     ports:
       - "1433:1433"
@@ -30,7 +30,7 @@ services:
   oracle_db:
     image: container-registry.oracle.com/database/express:latest
     environment:
-      ORACLE_PWD: "MySecretPassw0rd!"
+      ORACLE_PWD: "test_p@ssword_f0r_CI!"
     ports:
       - "1521:1521"
     networks:
@@ -39,7 +39,7 @@ services:
   mysql_db:
     image: mysql
     environment:
-      MYSQL_ROOT_PASSWORD: "MySecretPassw0rd!"
+      MYSQL_ROOT_PASSWORD: "test_p@ssword_f0r_CI!"
     ports:
       - "3306:3306"
     networks:

--- a/tests/integration/inputs/mssql_sqlconnect.env
+++ b/tests/integration/inputs/mssql_sqlconnect.env
@@ -1,2 +1,2 @@
 MSSQL_USERNAME=sa
-MSSQL_PASSWORD=MySecretPassw0rd!
+MSSQL_PASSWORD=test_p@ssword_f0r_CI!

--- a/tests/integration/inputs/mssql_sqlconnect.yaml
+++ b/tests/integration/inputs/mssql_sqlconnect.yaml
@@ -1,8 +1,10 @@
 connections:
   Mssql:
-    sqlalchemy_driver: 'mssql+pyodbc'
-    server: 'mssql_db:1433'
-    odbc_driver: 'ODBC+Driver+17+for+SQL+Server'
+    dialect: 'mssql'
+    dbapi: 'pyodbc'
+    host: 'mssql_db'
     database: 'master'
     username: '${MSSQL_USERNAME}'
     password: '${MSSQL_PASSWORD}'
+    options: 
+      driver: 'ODBC Driver 17 for SQL Server'

--- a/tests/integration/inputs/mysql_sqlconnect.env
+++ b/tests/integration/inputs/mysql_sqlconnect.env
@@ -1,2 +1,2 @@
 MYSQL_USERNAME=root
-MYSQL_PASSWORD=MySecretPassw0rd!
+MYSQL_PASSWORD=test_p@ssword_f0r_CI!

--- a/tests/integration/inputs/mysql_sqlconnect.yaml
+++ b/tests/integration/inputs/mysql_sqlconnect.yaml
@@ -1,8 +1,8 @@
 connections:
   Mysql:
-    sqlalchemy_driver: 'mysql+pymysql'
-    server: 'mysql_db:3306'
-    odbc_driver: ''
+    dialect: 'mysql'
+    dbapi: 'pymysql'
+    host: 'mysql_db'
     database: 'sys'
     username: '${MYSQL_USERNAME}'
     password: '${MYSQL_PASSWORD}'

--- a/tests/integration/inputs/oracle_sqlconnect.env
+++ b/tests/integration/inputs/oracle_sqlconnect.env
@@ -1,2 +1,2 @@
 ORACLE_USERNAME=system
-ORACLE_PASSWORD=MySecretPassw0rd!
+ORACLE_PASSWORD=test_p@ssword_f0r_CI!

--- a/tests/integration/inputs/oracle_sqlconnect.yaml
+++ b/tests/integration/inputs/oracle_sqlconnect.yaml
@@ -1,10 +1,9 @@
 connections:
   Oracle:
-    sqlalchemy_driver: 'oracle+oracledb'
-    server: 'oracle_db:1521'
-    odbc_driver: ''
-    database: ''
+    dialect: 'oracle'
+    dbapi: 'oracledb'
+    host: 'oracle_db'
     username: '${ORACLE_USERNAME}'
     password: '${ORACLE_PASSWORD}'
     options:
-      - 'service_name=XE'
+      service_name: 'XE'

--- a/tests/integration/inputs/postgres_sqlconnect.env
+++ b/tests/integration/inputs/postgres_sqlconnect.env
@@ -1,2 +1,2 @@
 POSTGRES_USERNAME=postgres
-POSTGRES_PASSWORD=mysecretpassword
+POSTGRES_PASSWORD=test_p@ssword_f0r_CI!

--- a/tests/integration/inputs/postgres_sqlconnect.yaml
+++ b/tests/integration/inputs/postgres_sqlconnect.yaml
@@ -1,8 +1,8 @@
 connections:
   Postgres:
-    sqlalchemy_driver: 'postgresql+psycopg2'
-    server: 'postgres_db:5432'
-    odbc_driver: ''
+    dialect: 'postgresql'
+    dbapi: 'psycopg2'
+    host: 'postgres_db'
     database: 'postgres'
     username: '${POSTGRES_USERNAME}'
     password: '${POSTGRES_PASSWORD}'

--- a/tests/integration/setup/migration.py
+++ b/tests/integration/setup/migration.py
@@ -11,14 +11,14 @@ DATABASE_URLS = [
         host="postgres_db",
         database="postgres",
         username="postgres",
-        password="mysecretpassword",
+        password="test_p@ssword_f0r_CI!",
     ),
     URL.create(
         "mssql+pyodbc",
         host="mssql_db",
         database="master",
         username="sa",
-        password="MySecretPassw0rd!",
+        password="test_p@ssword_f0r_CI!",
         query={"driver": "ODBC Driver 17 for SQL Server"},
     ),
     URL.create(
@@ -26,13 +26,13 @@ DATABASE_URLS = [
         host="mysql_db",
         database="sys",
         username="root",
-        password="MySecretPassw0rd!",
+        password="test_p@ssword_f0r_CI!",
     ),
     URL.create(
         "oracle+oracledb",
         host="oracle_db",
         username="system",
-        password="MySecretPassw0rd!",
+        password="test_p@ssword_f0r_CI!",
         query={"service_name": "XE"},
     ),
 ]
@@ -54,7 +54,7 @@ def insert_data(engine, employees, data):
         with engine.connect() as connection:
             connection.execute(employees.insert(), data)
             connection.commit()
-            print(f"Data inserted successfully into {connection.engine} ")
+            print(f"Test data inserted successfully into {connection.engine} ")
     except SQLAlchemyError as e:
         print(f"An error occurred during data insertion: {e}")
 

--- a/tests/integration/test_mysql.py
+++ b/tests/integration/test_mysql.py
@@ -38,7 +38,7 @@ def setup_connections():
         target_env.unlink()
 
 
-def test_sql_to_df_str_postgres(setup_env, setup_connections):
+def test_sql_to_df_str_mysql(setup_env, setup_connections):
     conn = sc.Sqlconnector("Mysql")
 
     df = conn.sql_to_df_str(

--- a/tests/integration/test_oracle.py
+++ b/tests/integration/test_oracle.py
@@ -38,7 +38,7 @@ def setup_connections():
         target_env.unlink()
 
 
-def test_sql_to_df_str_postgres(setup_env, setup_connections):
+def test_sql_to_df_str_oracle(setup_env, setup_connections):
     conn = sc.Sqlconnector("Oracle")
 
     df = conn.sql_to_df_str(

--- a/tests/test_sqlconnect_connector.py
+++ b/tests/test_sqlconnect_connector.py
@@ -1,11 +1,11 @@
 from sqlconnect import Sqlconnector
 
 CONFIG_DICT = {
-    "sqlalchemy_driver": "mssql+pyodbc",
-    "odbc_driver": "SQL+Server",
-    "server": "dev-server.database.com",
+    "dialect": "mssql",
+    "dbapi": "pyodbc",
+    "host": "dev-server.database.com",
     "database": "DevDB",
-    "options": ["Trusted_Connection=Yes"],
+    "options": {"Trusted_Connection=": "Yes", "driver": "SQL Server"},
 }
 
 
@@ -13,10 +13,7 @@ def test_Sqlconnector_connection_name_with_config_dict():
     # Test that Sqlconnector object connection name is correctly initialised
 
     # Creating an instance of Sqlconnector
-    connector = Sqlconnector("test_connection", config_dict=CONFIG_DICT)
+    connector = Sqlconnector("Database_One", config_dict=CONFIG_DICT)
 
     # Assertions to check if the instance is initialised as expected
-    assert connector.connection_name == "test_connection"
-
-
-# Test the sql functions for errors if given non-strings
+    assert connector.connection_name == "Database_One"


### PR DESCRIPTION
Update to the yaml structure used to create the SQLAlchemy database engine connection string. This structure is more generic for compatibility with Postgres, MySQL and Oracle database management systems. 

The config module now uses the SQLAlchemy URL.create() method to create the connection URL. This method handles edge cases like the '@' symbol in passwords and automatically provides port numbers.  

The new structure is generally not expected to change in future. 

Previous structure:
``` YAML
connections:
  Mssql:
    sqlalchemy_driver: 'mssql+pyodbc'
    server: 'mssql_db:1433'
    odbc_driver: 'ODBC+Driver+17+for+SQL+Server'
    database: 'master'
    username: '${MSSQL_USERNAME}'
    password: '${MSSQL_PASSWORD}'
```

New Structure:
``` YAML
connections:
  Mssql:
    dialect: 'mssql'
    dbapi: 'pyodbc'
    host: 'mssql_db'
    database: 'master'
    username: '${MSSQL_USERNAME}'
    password: '${MSSQL_PASSWORD}'
    options: 
      driver: 'ODBC Driver 17 for SQL Server'
```
